### PR TITLE
New testing mode: simulation vs regression

### DIFF
--- a/.github/workflows/job-examples.yml
+++ b/.github/workflows/job-examples.yml
@@ -47,3 +47,19 @@ jobs:
           --fill-in-method=interpolate \
           ./examples/test_user_defined_metrics/references/SineNoisy_res.csv \
           ./examples/test_user_defined_metrics/references/Sine_res.csv
+      - name: Run simulation-only test generation with mopyregtest command line tool
+        run: |
+          cd examples/generate_tests
+          /github/home/.local/bin/mopyregtest generate \
+            --mode=simulation \
+            ./gen_tests BlocksSimCheck_from_cli \
+            ~/".openmodelica/libraries/Modelica 4.0.0+maint.om/" \
+            Modelica.Blocks.Examples.Filter
+          cd gen_tests
+          python3 test_blockssimcheck_from_cli.py
+      - name: Run simulation-only test generation with script
+        run: |
+          cd examples/generate_tests
+          python3 gentests_simulation_check.py
+          cd gen_tests
+          python3 test_blockssimcheck_from_script.py

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MoPyRegtest.egg-info/
 /examples/test_user_defined_metrics/references/Sine_res_comparison.csv
 /tests/data/FlawedModels/results
 /tests/data/gentests
+venv

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Either by creating [Generator class objects](https://github.com/pstelzig/MoPyReg
 The folder [examples/generate_tests/README.md](https://github.com/pstelzig/MoPyRegtest/tree/master/examples/generate_tests/README.md) 
 has a detailed explanation on how to automatically generate tests.
 
+### Simulation-only testing
+For Modelica libraries with unit test models that contain built-in assertions, MoPyRegtest supports a simulation-only 
+mode where no reference results are needed. Tests simply verify that a model compiles, builds, and simulates 
+successfully.
+
+This can be used via the `--mode=simulation` flag on the CLI:
+```bash
+mopyregtest generate --mode=simulation ./gen_tests MyTest <package_folder> <model_names>
+```
+
+or via `mode="simulation"` in the `Generator` class, or by calling `check_simulation()` directly on a 
+`RegressionTest` instance. See the [examples/generate_tests/README.md](https://github.com/pstelzig/MoPyRegtest/tree/master/examples/generate_tests/README.md#simulation-only-mode) 
+for details.
+
 ## Prerequisites
 To use MoPyRegtest you need to have
 * a [Python 3](https://www.python.org/) distribution including the modules [`unittest`](https://docs.python.org/3/library/unittest.html), [`numpy`](https://numpy.org/) and [`pandas`](https://pandas.pydata.org/),

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,18 @@ Examples can be found in the [folder generate_tests](/examples/generate_tests)
 For a more in-depth explanation of automatic test case generation turn to
 [generate_tests/README.md](/examples/generate_tests/README.md).
 
+### Simulation-only testing
+Some Modelica libraries contain unit test models with built-in assertions, where the actual result timeseries 
+is not relevant — you only need to verify that the model compiles, builds, and simulates successfully.
+MoPyRegtest supports this with the `--mode=simulation` option (CLI) or `mode="simulation"` (script).
+
+Examples can be found in the [folder generate_tests](/examples/generate_tests):
+
+* **From the command line**: `mopyregtest generate --mode=simulation ./gen_tests MyTest <package_folder> <model_names>`
+* **From a script**: See [gentests_simulation_check.py](/examples/generate_tests/gentests_simulation_check.py)
+
+For more details, see [generate_tests/README.md](/examples/generate_tests/README.md#simulation-only-mode).
+
 ### Test for intentional failure
 MoPyRegtest can also be used to check for intentional failure of regression tests. See 
 [test_for_intentional_failure/README.md](/examples/test_for_intentional_failure/README.md).

--- a/examples/generate_tests/README.md
+++ b/examples/generate_tests/README.md
@@ -154,3 +154,44 @@ them into code in the test definition file, you _must turn them into a string_. 
 gen = mopyregtest.Generator(package_folder=package_folder, models_in_package=models_in_package,
                             metric="lambda r_ref, r_act: np.linalg.norm(r_ref[:, 1] - r_act[:, 1], ord=np.inf)")
 ```
+
+## Simulation-only mode
+Some Modelica libraries contain unit test models with built-in assertions. For these, you don't need to compare
+against reference results — you only want to verify that the model compiles, builds, and simulates successfully.
+
+MoPyRegtest supports this with `mode="simulation"`. In this mode, no reference results are generated or needed,
+and the generated tests use `check_simulation()` instead of `compare_result()`.
+
+### From the command line
+To generate a simulation-only test from the command line, use `--mode=simulation`:
+
+```bash
+cd examples/generate_tests
+mopyregtest generate --mode=simulation ./gen_tests BlocksSimCheck_from_cli ~/".openmodelica/libraries/Modelica 4.0.0+maint.om/" Modelica.Blocks.Examples.Filter
+```
+
+This will create the test file `gen_tests/test_blockssimcheck_from_cli.py` without any `references/` folder.
+You can run the generated test with `python3 gen_tests/test_blockssimcheck_from_cli.py`.
+
+### Using a generator script
+See [gentests_simulation_check.py](/examples/generate_tests/gentests_simulation_check.py) for a complete example.
+The key difference from a regression test is passing `mode="simulation"` to the `Generator` constructor:
+
+```python
+models_in_package = ["Modelica.Blocks.Examples.Filter"]
+
+gen = mopyregtest.Generator(package_folder=package_folder, models_in_package=models_in_package,
+                            mode="simulation")
+gen.generate_tests(test_folder=this_folder / "gen_tests", test_name="BlocksSimCheck_from_script",
+                   test_results_folder=this_folder / "results")
+```
+
+You can also use `check_simulation()` directly in manually written tests without the generator:
+
+```python
+tester = mopyregtest.RegressionTest(package_folder=package_folder,
+                                    model_in_package="Modelica.Blocks.Examples.Filter",
+                                    result_folder=result_folder)
+tester.check_simulation()
+tester.cleanup()
+```

--- a/examples/generate_tests/gentests_simulation_check.py
+++ b/examples/generate_tests/gentests_simulation_check.py
@@ -1,0 +1,42 @@
+import pathlib
+import platform
+import mopyregtest
+import sys
+
+# Setup the test data #########################################################
+# Example here for an Ubuntu environment with OpenModelica
+# installed like in https://openmodelica.org/download/download-linux
+# and using the default OpenModelica package manager
+
+# Path to Modelica library or model to be tested. Here an element of the Modelica STL.
+if platform.system() == 'Windows':
+    package_folder = pathlib.Path.home() / "AppData/Roaming/.openmodelica/libraries/Modelica 4.0.0+maint.om"
+else:
+    package_folder = pathlib.Path.home() / ".openmodelica/libraries/Modelica 4.0.0+maint.om"
+
+if not package_folder.exists():
+    error_msg = f"""[ERROR] Path \"{package_folder}\" not found. Aborting.
+
+This example is designed to work with OpenModelica installed to 
+standard paths, in order to work out of the box. 
+
+It requires the omc binary to be in the PATH variable and that the Modelica standard 
+library version 4.0.0 is installed to {package_folder}. 
+
+If this does not fit your requirements, just adapt the package_folder variable 
+in this file to your needs."""
+    print(error_msg)
+    sys.exit(-1)
+
+# Where to put results from this test
+this_folder = pathlib.Path(__file__).absolute().parent
+
+# Generating a simulation-only test battery ############################################################################
+# In simulation mode, no reference results are needed. The generated tests only check that the model
+# compiles, builds, and simulates successfully.
+models_in_package = ["Modelica.Blocks.Examples.Filter"]
+
+gen = mopyregtest.Generator(package_folder=package_folder, models_in_package=models_in_package,
+                            mode="simulation")
+gen.generate_tests(test_folder=this_folder / "gen_tests", test_name="BlocksSimCheck_from_script",
+                   test_results_folder=this_folder / "results")

--- a/mopyregtest/cli.py
+++ b/mopyregtest/cli.py
@@ -34,6 +34,7 @@ def generate(args):
     result_folder = "results"
     package_folder = args.package_folder
     models_in_package = args.models_in_package.split(",")
+    mode = args.mode
 
     if args.references is not None:
         ref_pairs = args.references.split(",")
@@ -54,7 +55,8 @@ def generate(args):
     if args.metric is not None:
         metric = metric_str_to_func(args.metric)
 
-    gen = Generator(package_folder=package_folder, models_in_package=models_in_package, metric=metric, tol=args.tol)
+    gen = Generator(package_folder=package_folder, models_in_package=models_in_package,
+                    mode=mode, metric=metric, tol=args.tol)
     gen.generate_tests(test_folder, test_name, result_folder, references)
 
     return
@@ -99,6 +101,12 @@ def parse_args(cmd_args):
     generate_parser.add_argument("models_in_package", type=str,
                                  help="Comma separated list of model names like <model name1>,<model name2> "
                                       "to be turned into regression tests")
+    generate_parser.add_argument("--mode", type=str,
+                                 help="Testing mode. 'regression' (default) generates tests that compare simulation "
+                                      "results against reference CSV files. 'simulation' generates tests that only "
+                                      "check whether the model simulates successfully, without reference comparison.",
+                                 choices=["regression", "simulation"],
+                                 default="regression")
     generate_parser.add_argument("--metric", type=str,
                                  help="Metric to be used. Choose here from predefined values. "
                                       "For user-defined metrics please consider creating the tests with a dedicated script. "

--- a/mopyregtest/generator.py
+++ b/mopyregtest/generator.py
@@ -71,6 +71,24 @@ class Test$$CLASS_NAME$$(unittest.TestCase):
         return
         """
 
+    METHOD_CHECK_SIM = \
+        """
+    def test_$$METHOD_NAME$$(self):
+        tester = mopyregtest.RegressionTest(package_folder="$$PACKAGE_FOLDER$$",
+                                            model_in_package="$$MODEL_IN_PACKAGE$$",
+                                            result_folder="$$RESULT_FOLDER$$",
+                                            modelica_version="$$MODELICA_VERSION$$",
+                                            dependencies=$$DEPENDENCIES$$)
+    
+        # Check that simulation completes successfully
+        tester.check_simulation()
+    
+        # Deletes result_folder after it has been created. Leave out if you feel uncomfortable with auto-deletion!
+        $$DO_CLEANUP$$tester.cleanup()
+    
+        return
+        """
+
     MAIN_STATEMENT = \
         """
 if __name__ == '__main__':
@@ -78,6 +96,7 @@ if __name__ == '__main__':
         """
 
     def __init__(self, package_folder, models_in_package, modelica_version="default", dependencies=None,
+                 mode="regression",
                  metric=metrics.norm_infty_dist,
                  tol=1e-7, unify_timestamps=True, fill_in_method="ffill"):
         """
@@ -95,6 +114,10 @@ if __name__ == '__main__':
             Optional list of strings with names of packages that the package to be tested depends on.
             Each dependency must point to the .mo file that defines the dependency. E.g. if the
             dependency is an entire package, it must be the path to the respective package's package.mo.
+        mode : str
+            Testing mode. "regression" (default) generates tests that compare simulation results against
+            reference CSV files. "simulation" generates tests that only check whether the model compiles,
+            builds, and simulates successfully, without any reference comparison.
         metric : function or str
             Metric to be used in result comparison. Important: If the metric is given as a funtion, one must use one
             of the predefined metrics, i.e. mopyregtest.metrics.norm_p_dist, mopyregtest.metrics.norm_infty_dist,
@@ -123,6 +146,11 @@ if __name__ == '__main__':
         self.models_in_package = models_in_package
         self.modelica_version = modelica_version
         self.dependencies = dependencies
+
+        if mode not in ["regression", "simulation"]:
+            raise ValueError(f"Invalid mode '{mode}'. Must be 'regression' or 'simulation'.")
+        self.mode = mode
+
         if (callable(metric) and
                 metric in [metrics.norm_p_dist, metrics.norm_infty_dist,
                            metrics.Lp_dist, metrics.Linfty_dist,
@@ -234,8 +262,10 @@ if __name__ == '__main__':
         test_folder = pathlib.Path(test_folder)
         if not test_folder.exists():
             test_folder.mkdir(parents=True, exist_ok=False)
-        if not (test_folder / "references").exists():
-            (test_folder / "references").mkdir()
+
+        if self.mode == "regression":
+            if not (test_folder / "references").exists():
+                (test_folder / "references").mkdir()
 
         # Creating the MoPyRegtest test definition
         tfile = open(pathlib.Path(test_folder) / f"test_{test_name.lower()}.py", 'w')
@@ -245,12 +275,13 @@ if __name__ == '__main__':
 
         # Creating a test method for every element in self.models_in_package
         for md in self.models_in_package:
-            r_ref_relpath = f"references/{md}_res.csv"
-            if (references is None or md not in references.keys()) and generate_missing_refs:
-                self._generate_reference(reference_folder=test_folder / "references",
-                                         model_in_package=md, do_cleanup=cleanup_ref_gen)
-            else:
-                shutil.copyfile(references[md], str(test_folder / r_ref_relpath))
+            if self.mode == "regression":
+                r_ref_relpath = f"references/{md}_res.csv"
+                if (references is None or md not in references.keys()) and generate_missing_refs:
+                    self._generate_reference(reference_folder=test_folder / "references",
+                                             model_in_package=md, do_cleanup=cleanup_ref_gen)
+                else:
+                    shutil.copyfile(references[md], str(test_folder / r_ref_relpath))
 
             # If the package path is relative, compute its relative path to the target test folder
             if not pathlib.PurePath(test_folder).is_absolute():
@@ -273,15 +304,20 @@ if __name__ == '__main__':
                 "$$RESULT_FOLDER$$": str(pathlib.Path(test_results_folder).as_posix()),
                 "$$MODELICA_VERSION$$": self.modelica_version,
                 "$$DEPENDENCIES$$": dependencies_str,
-                "$$REFERENCE_RESULT$$": str(pathlib.Path(r_ref_relpath).as_posix()),
-                "$$METRIC$$": self.metric,
-                "$$TOLERANCE$$": str(self.tol),
-                "$$UNIFY_TIMESTAMPS$$": str(self.unify_timestamps),
-                "$$FILL_IN_METHOD$$": self.fill_in_method,
                 "$$DO_CLEANUP$$": "" if cleanup_in_tests else "#"
             }
 
-            test_method = utils.replace_in_str(Generator.METHOD, repl_dict)
+            if self.mode == "regression":
+                repl_dict["$$REFERENCE_RESULT$$"] = str(pathlib.Path(r_ref_relpath).as_posix())
+                repl_dict["$$METRIC$$"] = self.metric
+                repl_dict["$$TOLERANCE$$"] = str(self.tol)
+                repl_dict["$$UNIFY_TIMESTAMPS$$"] = str(self.unify_timestamps)
+                repl_dict["$$FILL_IN_METHOD$$"] = self.fill_in_method
+                template = Generator.METHOD
+            else:
+                template = Generator.METHOD_CHECK_SIM
+
+            test_method = utils.replace_in_str(template, repl_dict)
             tfile.write(test_method)
             tfile.flush()
 

--- a/mopyregtest/modelicaregressiontest.py
+++ b/mopyregtest/modelicaregressiontest.py
@@ -317,6 +317,31 @@ class RegressionTest:
 
         return
 
+    def check_simulation(self):
+        """
+        Executes the simulation of the Modelica model specified in the constructor and checks that it
+        completes successfully. No comparison against a reference result is performed.
+
+        This is useful for Modelica libraries that have a battery of unit tests where the models contain
+        built-in assertions, and the user only needs to verify that the model compiles, builds, and
+        simulates without error.
+
+        Raises AssertionError if the simulation binary or result CSV file is not produced.
+
+        Returns
+        -------
+        out : None
+        """
+        print("\nChecking simulation of model {}".format(self.model_in_package))
+
+        self._import_and_simulate()
+
+        simulation_result = str(self.result_folder_path / self.model_in_package) + "_res.csv"
+        print("Simulation of model {} completed successfully. Result at {}".format(
+            self.model_in_package, simulation_result))
+
+        return
+
     def compare_result(self, reference_result, tol=1e-7, validated_cols=[],
                        metric=metrics.norm_infty_dist,
                        unify_timestamps=True, fill_in_method="ffill", write_comparison=True):

--- a/tests/test_check_simulation.py
+++ b/tests/test_check_simulation.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+import pathlib
+import mopyregtest
+
+this_folder = pathlib.Path(__file__).absolute().parent
+initial_cwd = os.getcwd()
+
+class TestCheckSimulation(unittest.TestCase):
+    def test_check_simulation_success(self):
+        """
+        Test that check_simulation passes for a model that builds and simulates.
+        DoesNotFinish builds and produces a result CSV, even though it does not reach
+        the simulation end time. check_simulation should succeed because a result is produced.
+        """
+        os.chdir(initial_cwd)
+
+        tester = mopyregtest.RegressionTest(package_folder=this_folder / "data/FlawedModels",
+                                           model_in_package="FlawedModels.DoesNotFinish",
+                                           result_folder=this_folder / "data/FlawedModels/results")
+
+        tester.check_simulation()
+
+        tester.cleanup(ask_confirmation=False)
+
+        return
+
+    def test_check_simulation_build_failure(self):
+        """
+        Test that check_simulation raises AssertionError for a model that does not build.
+        """
+        os.chdir(initial_cwd)
+
+        tester = mopyregtest.RegressionTest(package_folder=this_folder / "data/FlawedModels",
+                                           model_in_package="FlawedModels.DoesNotBuild",
+                                           result_folder=this_folder / "data/FlawedModels/results")
+
+        self.assertRaises(AssertionError, tester.check_simulation)
+
+        tester.cleanup(ask_confirmation=False)
+
+        return
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,36 @@ class TestCli(unittest.TestCase):
 
         return
 
+    def test_generate_simulation_mode(self):
+        """
+        Testing --mode=simulation in CLI: mopyregtest generate
+        Verifies that generated test file uses check_simulation() and no references folder is created.
+        """
+        gentests_folder = this_folder / "data/gentests_simmode"
+        cmd_args = ["generate",
+                    "--mode=simulation",
+                    str(gentests_folder),
+                    "FlawedModels_SimCheck",
+                    str(this_folder / "data/FlawedModels"),
+                    "FlawedModels.DoesNotFinish"]
+
+        cli.parse_args(cmd_args)
+
+        # Verify the generated test file contains check_simulation and not compare_result
+        generated_file = gentests_folder / "test_flawedmodels_simcheck.py"
+        self.assertTrue(generated_file.exists())
+        content = generated_file.read_text()
+        self.assertIn("check_simulation()", content)
+        self.assertNotIn("compare_result(", content)
+
+        # Verify no references folder was created
+        self.assertFalse((gentests_folder / "references").exists())
+
+        # Clean up
+        shutil.rmtree(gentests_folder)
+
+        return
+
     def test_compare1(self):
         """
         Testing for default arguments in CLI: mopyregtest compare


### PR DESCRIPTION
Adding a new flag called --mode that allows to choose between "regression" (default) and "simulation" (just whether simulation runs through successfully, for Modelica unit tests)